### PR TITLE
Fix floor button issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,10 +44,13 @@ function setupBuilding() {
 	const floor0 = makeFloor("1");
 
 	window.goToFloor = function (num) {
+		if (num == "1") {
+			num = "0"
+		}
 		floor7.dataset.active = "7" == num ? 1 : 0;
 		floor8.dataset.active = "8" == num ? 1 : 0;
 		floor9.dataset.active = "9" == num ? 1 : 0;
-		floor0.dataset.active = "0" == num || "1" == num ? 1 : 0;
+		floor0.dataset.active = "0" == num ? 1 : 0;
 		building.dataset.floor = num;
 	};
 

--- a/style.css
+++ b/style.css
@@ -123,6 +123,10 @@ body {
 	user-select: none;
 }
 
+#building > .buttons > button:focus-visible {
+	outline: none;
+}
+
 #building > .buttons > button:hover {
 	background: #aaa;
 	color: #eee;


### PR DESCRIPTION
There seem to be two separate issues with the floor buttons:
1) Typing "1" after refresh will not highlight the "10" button
2) Clicking a button (e.g., "7") and then typing a different number (e.g., "1") will leave a focus highlight around the first button.